### PR TITLE
aded proper sorting of packages by their semantic version

### DIFF
--- a/src/Dizzy/Dizzy.psm1
+++ b/src/Dizzy/Dizzy.psm1
@@ -24,3 +24,4 @@ $VerbosePreference = "Continue"
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "Nuget.Core" "lib\net40-client\NuGet.Core.dll"))
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "LibGit2Sharp" "LibGit2Sharp.dll"))
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "GitVersion" "lib\net45\GitVersionCore.dll"))
+[System.Reflection.Assembly]::LoadFrom((Resolve-Path "NuGet.CommandLine" "tools\NuGet.exe"))

--- a/src/Dizzy/Dizzy.psm1
+++ b/src/Dizzy/Dizzy.psm1
@@ -24,4 +24,4 @@ $VerbosePreference = "Continue"
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "Nuget.Core" "lib\net40-client\NuGet.Core.dll"))
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "LibGit2Sharp" "LibGit2Sharp.dll"))
 [System.Reflection.Assembly]::LoadFrom((ResolvePath "GitVersion" "lib\net45\GitVersionCore.dll"))
-[System.Reflection.Assembly]::LoadFrom((Resolve-Path "NuGet.CommandLine" "tools\NuGet.exe"))
+[System.Reflection.Assembly]::LoadFrom((ResolvePath "NuGet.CommandLine" "tools\NuGet.exe"))

--- a/src/Dizzy/Install-ScNugetPackage.ps1
+++ b/src/Dizzy/Install-ScNugetPackage.ps1
@@ -104,10 +104,15 @@ function Install-ScNugetPackage {
             $packages = & $nuget list $packageId -Source $source -AllVersions -PreRelease | Where-Object { $_ -Like "$packageId*" }
 
             foreach ($pattern in $versionPatterns) {
-                $possiblePackage = $packages | Where-Object { $_ -like "* $pattern" } | Select-Object -Last 1
-                if ($possiblePackage) {
-                    return ($possiblePackage -Split ' ')[1]
-                }            
+                $possiblePackages = $packages | Where-Object { $_ -like "* $pattern" } 
+                if ($possiblePackages.Count -eq 1) {
+                    return $possiblePackages.Split(" ")[1]
+                }
+            
+                $newestVersion = $possiblePackages | ForEach-Object { [NuGet.Versioning.SemanticVersion]::Parse($_.Split(" ")[1]) } | Sort-Object | Select-Object -Last 1 | ForEach-Object { $_.ToString() }
+                if ($newestVersion) {
+                    return $newestVersion
+                }                        
             }
         }
 


### PR DESCRIPTION
After updating Nuget.CommandLine from 2* to 5* the packages were taken in more or less random order (depending on the package). 

Nuget changed a lot in between those versions, for example that from 4.3.0 they use Semantic Versioning 2.0.0.

I wanted to take advantage of this and follow Nuget's way when finding the latest version of a package - possible packages are sorted by their version.