### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -12,4 +12,4 @@ NUGET
     Pester (4.0.8)
     Unic.Bob.Keith (2.0.2)
     Unic.Bob.Skip (4.0.5)
-    Unic.Bob.Wendy (3.2.1)
+    Unic.Bob.Wendy (3.2)

--- a/paket.lock
+++ b/paket.lock
@@ -11,5 +11,5 @@ NUGET
       Microsoft.Web.Xdt (>= 2.1)
     Pester (4.0.8)
     Unic.Bob.Keith (2.0.2)
-    Unic.Bob.Skip (4.0.4)
-    Unic.Bob.Wendy (3.0.1)
+    Unic.Bob.Skip (4.0.5)
+    Unic.Bob.Wendy (3.2.1)

--- a/src/Dizzy/Dizzy.psm1
+++ b/src/Dizzy/Dizzy.psm1
@@ -15,7 +15,7 @@ function ResolvePath() {
   Write-Error "No path found for $RelativePath in package $PackageId"
 }
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *
 
 Import-Module (ResolvePath "Unic.Bob.Wendy" "tools\Wendy") -force


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that.